### PR TITLE
Update durable-functions-webjobs-sdk.md

### DIFF
--- a/articles/azure-functions/durable/durable-functions-webjobs-sdk.md
+++ b/articles/azure-functions/durable/durable-functions-webjobs-sdk.md
@@ -214,50 +214,63 @@ This section provides an overview of how to run the [sample project](https://git
 
 ## WebJobs SDK 3.x
 
-This article explains how to develop a WebJobs SDK 2.x project. If you're developing a WebJobs SDK 3.x project, this section helps you understand the differences.
+This article explains how to develop a WebJobs SDK 2.x project. If you're developing a [WebJobs SDK 3.x](../../app-service/webjobs-sdk-get-started) project, this section helps you understand the differences.
 
 The main change introduced is the use of .NET Core instead of .NET Framework. To create a WebJobs SDK 3.x project, the instructions are the same, with these exceptions:
 
-1. Create a .NET Core console app. In the Visual Studio **New Project** dialog box, select  **.NET Core** > **Console App (.NET Core)**. The project file specifies that `TargetFramework` is `netcoreapp2.0`.
+1. Create a .NET Core console app. In the Visual Studio **New Project** dialog box, select  **.NET Core** > **Console App (.NET Core)**. The project file specifies that `TargetFramework` is `netcoreapp2.x`.
 
-1. Choose the prerelease version WebJobs SDK 3.x of the following packages:
+1. Choose the release version WebJobs SDK 3.x of the following packages:
 
     * `Microsoft.Azure.WebJobs.Extensions`
+    * `Microsoft.Azure.WebJobs.Extensions.Storage`
     * `Microsoft.Azure.WebJobs.Logging.ApplicationInsights`
 
-1. Get the storage connection string and the Application Insights instrumentation key from an *appsettings.json* file, by using the .NET Core configuration framework. Change the `Main` method code to do this. Here's an example:
+1. Set the storage connection string and the Application Insights instrumentation key in an *appsettings.json* file, by using the .NET Core configuration framework. Here's an example:
+
+    ```json
+        {
+            "AzureWebJobsStorage": "<replace with storage connection string>",
+            "APPINSIGHTS_INSTRUMENTATIONKEY": "<replace with Application Insights instrumentation key>"
+        }
+    ```
+
+1. Change the `Main` method code to do this. Here's an example:
 
    ```cs
    static void Main(string[] args)
    {
-       var builder = new ConfigurationBuilder()
-           .SetBasePath(Directory.GetCurrentDirectory())
-           .AddJsonFile("appsettings.json");
+        var hostBuilder = new HostBuilder()
+        .ConfigureWebJobs(config =>
+        {
+            config.AddAzureStorageCoreServices();
+            config.AddAzureStorage();
+            config.AddTimers();
 
-       var appSettingsConfig = builder.Build();
+            config.AddDurableTask(options =>
+            {
+                options.HubName = "MyTaskHub";
+                options.AzureStorageConnectionStringName = "AzureWebJobsStorage";
+            });
+        })
 
-       using (var loggerFactory = new LoggerFactory())
-       {
-           var config = new JobHostConfiguration();
+        .ConfigureLogging((context, logging) =>
+        {
+            logging.AddConsole();
+            logging.AddApplicationInsights(config =>
+            {
+                config.InstrumentationKey = context.Configuration["APPINSIGHTS_INSTRUMENTATIONKEY"];
+            });
+        })
 
-           config.DashboardConnectionString = "";
-           config.StorageConnectionString =
-               appSettingsConfig.GetConnectionString("AzureWebJobsStorage");
-           var instrumentationKey =
-               appSettingsConfig["APPINSIGHTS_INSTRUMENTATIONKEY"];
+        .UseConsoleLifetime();
 
-           config.LoggerFactory = loggerFactory
-               .AddApplicationInsights(instrumentationKey, null)
-               .AddConsole();
+        var host = hostBuilder.Build();
 
-           config.UseTimers();
-           config.UseDurableTask(new DurableTaskExtension
-           {
-               HubName = "MyTaskHub",
-           });
-           var host = new JobHost(config);
-           host.RunAndBlock();
-       }
+        using (host)
+        {
+            host.Run();
+        }
    }
    ```
 


### PR DESCRIPTION
- Addressing [issue 590](https://github.com/Azure/azure-functions-durable-extension/issues/590): Update the code example of ["How to run Durable functions as WebJobs"](https://docs.microsoft.com/en-us/azure/azure-functions/durable/durable-functions-webjobs-sdk), for WebJobs SDK 3.x.